### PR TITLE
Fix revert umount sepolicy

### DIFF
--- a/module/src/sepolicy.rule
+++ b/module/src/sepolicy.rule
@@ -14,4 +14,4 @@ allow zygote adb_data_file dir search
 allow zygote mnt_vendor_file dir search
 allow zygote system_file dir mounton
 allow zygote labeledfs filesystem mount
-allow zygote labeledfs filesystem unmount
+allow zygote fs_type filesystem unmount

--- a/module/src/sepolicy.rule
+++ b/module/src/sepolicy.rule
@@ -14,3 +14,4 @@ allow zygote adb_data_file dir search
 allow zygote mnt_vendor_file dir search
 allow zygote system_file dir mounton
 allow zygote labeledfs filesystem mount
+allow zygote labeledfs filesystem unmount


### PR DESCRIPTION
```
03-13 10:09:39.676 21245 21245 E zygisksu64: Unmount (/apex/com.android.art/bin/dex2oat64) failed with 13: Permission denied
03-13 10:09:39.676 21245 21245 E zygisksu64: Unmount (/apex/com.android.art/bin/dex2oat32) failed with 13: Permission denied
03-13 10:09:39.676 21245 21245 E zygisksu64: Unmount (/system) failed with 13: Permission denied
03-13 10:09:39.676 21245 21245 E zygisksu64: Unmount (/data/adb/modules) failed with 13: Permission denied
03-13 10:09:39.672 21245 21245 W main    : type=1400 audit(0.0:23827516): avc: denied { unmount } for scontext=u:r:zygote:s0 tcontext=u:object_r:labeledfs:s0 tclass=filesystem permissive=0
```