### PR TITLE
several changes

### DIFF
--- a/loader/src/common/dl.cpp
+++ b/loader/src/common/dl.cpp
@@ -44,8 +44,28 @@ void* DlopenExt(const char* path, int flags) {
     return handle;
 }
 
-void* DlopenMem(int memfd, int flags) {
-    char path[PATH_MAX];
-    sprintf(path, "/proc/self/fd/%d", memfd);
-    return DlopenExt(path, flags);
+void* DlopenMem(int fd, int flags) {
+    auto info = android_dlextinfo{};
+    auto* ns = &__loader_android_create_namespace == nullptr ? nullptr :
+               __loader_android_create_namespace("", "", nullptr,
+                                                 2, /* ANDROID_NAMESPACE_TYPE_SHARED */
+                                                 nullptr, nullptr,
+                                                 reinterpret_cast<void*>(&DlopenExt));
+    if (ns) {
+        info.flags = ANDROID_DLEXT_USE_NAMESPACE | ANDROID_DLEXT_USE_LIBRARY_FD;
+        info.library_namespace = ns;
+        info.library_fd = fd;
+
+        LOGD("Open fd %d with namespace %p", fd, ns);
+    } else {
+        LOGD("Cannot create namespace for fd %d", fd);
+    }
+
+    auto* handle = android_dlopen_ext("/jit-cache", flags, &info);
+    if (handle) {
+        LOGD("dlopen fd %d: %p", fd, handle);
+    } else {
+        LOGE("dlopen fd %d: %s", fd, dlerror());
+    }
+    return handle;
 }

--- a/loader/src/common/dl.cpp
+++ b/loader/src/common/dl.cpp
@@ -45,21 +45,10 @@ void* DlopenExt(const char* path, int flags) {
 }
 
 void* DlopenMem(int fd, int flags) {
-    auto info = android_dlextinfo{};
-    auto* ns = &__loader_android_create_namespace == nullptr ? nullptr :
-               __loader_android_create_namespace("", "", nullptr,
-                                                 2, /* ANDROID_NAMESPACE_TYPE_SHARED */
-                                                 nullptr, nullptr,
-                                                 reinterpret_cast<void*>(&DlopenExt));
-    if (ns) {
-        info.flags = ANDROID_DLEXT_USE_NAMESPACE | ANDROID_DLEXT_USE_LIBRARY_FD;
-        info.library_namespace = ns;
-        info.library_fd = fd;
-
-        LOGD("Open fd %d with namespace %p", fd, ns);
-    } else {
-        LOGD("Cannot create namespace for fd %d", fd);
-    }
+    auto info = android_dlextinfo{
+        .flags = ANDROID_DLEXT_USE_LIBRARY_FD,
+        .library_fd = fd
+    };
 
     auto* handle = android_dlopen_ext("/jit-cache", flags, &info);
     if (handle) {

--- a/loader/src/include/daemon.h
+++ b/loader/src/include/daemon.h
@@ -20,7 +20,7 @@ public:
 
     UniqueFd(Fd fd) : fd_(fd) {}
 
-    ~UniqueFd() { close(fd_); }
+    ~UniqueFd() { if (fd_ >= 0) close(fd_); }
 
     // Disallow copy
     UniqueFd(const UniqueFd&) = delete;

--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -45,8 +45,8 @@ androidComponents.onVariants { variant ->
             include("module.prop")
             expand(
                 "moduleId" to moduleId,
-                "moduleName" to moduleName,
-                "versionName" to "$verName ($verCode)",
+                "moduleName" to "$moduleName-$variantCapped",
+                "versionName" to "$verName ($verCode)-($variantCapped)",
                 "versionCode" to verCode,
             )
         }

--- a/module/src/customize.sh
+++ b/module/src/customize.sh
@@ -80,6 +80,11 @@ extract "$ZIPFILE" 'customize.sh'  "$TMPDIR/.vunzip"
 extract "$ZIPFILE" 'verify.sh'     "$TMPDIR/.vunzip"
 extract "$ZIPFILE" 'sepolicy.rule' "$TMPDIR"
 
+if [ "$DEBUG" = true ]; then
+  ui_print "- Add debug SELinux policy"
+  echo "allow crash_dump adb_data_file dir search" >> "$TMPDIR/sepolicy.rule"
+fi
+
 if [ "$KSU" ]; then
   ui_print "- Checking SELinux patches"
   if ! check_sepolicy "$TMPDIR/sepolicy.rule"; then

--- a/zygiskd/Cargo.toml
+++ b/zygiskd/Cargo.toml
@@ -14,7 +14,7 @@ konst = "0.3.4"
 lazy_static = "1.4.0"
 log = "0.4.17"
 memfd = "0.6.2"
-nix = { version = "0.26.2", features = ["process"] }
+nix = { version = "0.26.2", features = ["process","poll"] }
 num_enum = "0.5.9"
 once_cell = "1.17.1"
 passfd = "0.1.5"

--- a/zygiskd/Cargo.toml
+++ b/zygiskd/Cargo.toml
@@ -14,7 +14,7 @@ konst = "0.3.4"
 lazy_static = "1.4.0"
 log = "0.4.17"
 memfd = "0.6.2"
-nix = "0.26.2"
+nix = { version = "0.26.2", features = ["process"] }
 num_enum = "0.5.9"
 once_cell = "1.17.1"
 passfd = "0.1.5"

--- a/zygiskd/src/utils.rs
+++ b/zygiskd/src/utils.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, ensure, Result};
 use nix::unistd::gettid;
 use std::{fs, io::{Read, Write}, os::unix::net::UnixStream, process::Command};
 use std::ffi::c_char;


### PR DESCRIPTION
- make symbol information available on backtrace in debug build
- create zygiskd companion process as daemon
- create zygiskd companion in need
- use ANDROID_DLEXT_USE_LIBRARY_FD to dlopen fds
- indicate build type in module name and version