### PR TITLE
Add back `#[inline(never)]`

### DIFF
--- a/zygiskd/src/root_impl/kernelsu.rs
+++ b/zygiskd/src/root_impl/kernelsu.rs
@@ -24,12 +24,14 @@ pub fn get_kernel_su() -> Option<Version> {
     }
 }
 
+#[inline(never)]
 pub fn uid_granted_root(uid: i32) -> bool {
     let mut granted = false;
     unsafe { prctl(KERNEL_SU_OPTION, CMD_UID_GRANTED_ROOT, uid, &mut granted as *mut bool) };
     granted
 }
 
+#[inline(never)]
 pub fn uid_should_umount(uid: i32) -> bool {
     let mut umount = false;
     unsafe { prctl(KERNEL_SU_OPTION, CMD_UID_SHOULD_UMOUNT, uid, &mut umount as *mut bool) };

--- a/zygiskd/src/root_impl/magisk.rs
+++ b/zygiskd/src/root_impl/magisk.rs
@@ -23,6 +23,7 @@ pub fn get_magisk() -> Option<Version> {
     })
 }
 
+#[inline(never)]
 pub fn uid_granted_root(uid: i32) -> bool {
     let output: Option<String> = Command::new("magisk")
         .arg("--sqlite")
@@ -40,6 +41,7 @@ pub fn uid_granted_root(uid: i32) -> bool {
     })
 }
 
+#[inline(never)]
 pub fn uid_should_umount(uid: i32) -> bool {
     // TODO: uid_should_umount
     return false;

--- a/zygiskd/src/root_impl/mod.rs
+++ b/zygiskd/src/root_impl/mod.rs
@@ -41,6 +41,8 @@ pub fn get_impl() -> &'static RootImpl {
     unsafe { &ROOT_IMPL }
 }
 
+// FIXME: Without #[inline(never)], this function will lag forever
+#[inline(never)]
 pub fn uid_granted_root(uid: i32) -> bool {
     match get_impl() {
         RootImpl::KernelSU => kernelsu::uid_granted_root(uid),
@@ -49,6 +51,7 @@ pub fn uid_granted_root(uid: i32) -> bool {
     }
 }
 
+#[inline(never)]
 pub fn uid_should_umount(uid: i32) -> bool {
     match get_impl() {
         RootImpl::KernelSU => kernelsu::uid_should_umount(uid),


### PR DESCRIPTION
Fix random failures

Partial revert 954a712089ec67929f7a6a801e17b462f29e9253